### PR TITLE
31 make buttons larger

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    celluloid (0.16.1)
+    celluloid (0.16.0)
       timers (~> 4.0.0)
     chunky_png (1.3.4)
     coderay (1.1.0)
@@ -44,7 +44,7 @@ GEM
     haml (4.0.6)
       tilt
     hike (1.2.3)
-    hitimes (1.2.2)
+    hitimes (1.2.3)
     hooks (0.4.0)
       uber (~> 0.0.4)
     http_parser.rb (0.6.0)
@@ -152,7 +152,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
-    timers (4.0.1)
+    timers (4.0.4)
       hitimes
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -180,4 +180,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/source/stylesheets/_install.scss
+++ b/source/stylesheets/_install.scss
@@ -82,9 +82,9 @@
     padding-left: 30px;
     padding-right: 20px;
     border: 1px solid white;
-    width: 43%;
-    padding-top: 10px;
-    padding-bottom: 10px;
+    width: 50%;
+    padding-top: 15px;
+    padding-bottom: 15px;
     display: block;
     color: black;
     margin-top: 20px;


### PR DESCRIPTION
Closes #31 
Ok, the buttons are a bit larger now :)

If you want the colours inverted to make them stand out more (button background white, button text same colour as background) the customhelpers file will need to be amended so it provides a classname for the button text to use too. Currently it returns a random classname e.g. bg-yellow which sets the bg colour when a partial loads