### PR TITLE
Fixed broken link

### DIFF
--- a/source/linux/useful/index.html.erb
+++ b/source/linux/useful/index.html.erb
@@ -1,7 +1,7 @@
 <%= partial(:'partials/header', :locals => { :title => "Useful tools" }) %>
 <div class="row essentialtools">
   <div class="wow fadeInUp essentialtools__col essentialtools__col--3 col-lg-15 col-md-15 col-sm-12 col-xs-12">
-    <% link_to "Rails.html" do %>
+    <% link_to "rails.html" do %>
     <h3>Rails</h3>
     <%= image_tag 'logo-rails.png', :class => 'logo__columns' %>
     <span>Set up Rails</span>


### PR DESCRIPTION
There was a spelling error in that created a broken link. As a result
there was no web page. I changed the spelling for 'Rails' to 'rails'.
This fixes #52.