### PR TITLE
Closes #63 The install Vim button doesn't transition nicely

### DIFF
--- a/source/stylesheets/_install.scss
+++ b/source/stylesheets/_install.scss
@@ -43,6 +43,7 @@
   }
 
   a {
+    transition: 0.6s all ease;
     color: white;
   }
 


### PR DESCRIPTION
The 'install Vim' button was an anchor tag, so it didn't have the
transition effect like the other texts did.